### PR TITLE
Provide two new modalities for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then:
 ```sh
 sudo modprobe msr
 sudo bash -c 'echo "msr" > /etc/modules-load.d/msr.conf'
-sudo apt install build-essential libgtk-3-dev git
+sudo apt install build-essential libgtk-3-dev libncurses5-dev git
 cd ~
 git clone https://github.com/Ta180m/zenmonitor3
 cd zenmonitor3

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ build:
 	$(CC) -Isrc/include `pkg-config --cflags gtk+-3.0` $(BUILD_FILES_GUI) -o zenmonitor `pkg-config --libs gtk+-3.0` -lm -no-pie -Wall $(CFLAGS)
 
 build-cli:
-	$(CC) -Isrc/include `pkg-config --cflags glib-2.0` $(BUILD_FILES_CLI) -o zenmonitor-cli `pkg-config --libs glib-2.0` -lm -no-pie -Wall $(CFLAGS)
+	$(CC) -Isrc/include `pkg-config --cflags glib-2.0` $(BUILD_FILES_CLI) -o zenmonitor-cli `pkg-config --libs glib-2.0` -lm -lncurses -no-pie -Wall $(CFLAGS)
 
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin

--- a/makefile
+++ b/makefile
@@ -52,6 +52,9 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/share/applications/zenmonitor-root.desktop
 	rm -f $(DESTDIR)/usr/share/polkit-1/actions/org.pkexec.zenmonitor.policy
 
+uninstall-cli:
+	rm -f $(DESTDIR)$(PREFIX)/bin/zenmonitor-cli
+
 all: build build-cli
 
 clean:

--- a/src/zenmonitor-cli.c
+++ b/src/zenmonitor-cli.c
@@ -14,6 +14,7 @@ gdouble delay = 0.5;
 gchar *file = "";
 SensorDataStore *store;
 int quit = 0;
+int output_once = 0;
 
 static GOptionEntry options[] = {
     {"file", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &file,
@@ -22,6 +23,8 @@ static GOptionEntry options[] = {
      "Interval of refreshing informations", "SECONDS"},
     {"coreid", 'c', 0, G_OPTION_ARG_NONE, &display_coreid,
      "Display core_id instead of core index", NULL},
+    {"output-once", 'o', 0, G_OPTION_ARG_NONE, &output_once,
+     "Output CPU information once and quit", NULL},
     {NULL}};
 
 static SensorSource sensor_sources[] = {
@@ -164,8 +167,12 @@ void update_data()
 void start_watching()
 {
     while(!quit)
-    {
+    {   
         update_data();
+        if (output_once)
+        {
+            break;
+        }
         usleep(delay * 1000 * 1000);
     }
 }
@@ -190,7 +197,6 @@ int main(int argc, char *argv[])
 
     init_sensors();
     start_watching();
-
     sensor_data_store_free(store);
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Hey there,

I initially thank you for this fork. It allowed me to monitor my CPU flawlessly. This PR involves the changes I made locally to make use of the CLI program through Conky. I'm not a Conky expert, so I was not really sure whether the current version of CLI is directly usable with some Lua scripting. Instead of that, I went ahead with providing the following two options:

1. `--output-once`. This simple flag allows the CLI program to finish immediately after printing the latest information about the CPU. I'm using it to update my Conky widget, however, it can be used by any such monitoring application. 
2. `--refresh-in-place`. This is also a simple flag. It pops up an `ncurses` windows and flushes the information block. This might be useful for those who want to embed the terminal output into widgets. It requires `libncurses5-dev` to be installed as I added to README.

This diff allowed me to monitor my 8-core Ryzen 7 5800H CPU in a very neat way 🙂 

![conky](https://user-images.githubusercontent.com/10549928/144102208-06df0777-7237-4410-adfa-7f1590557b8d.png)
 